### PR TITLE
Update loop to print correct data

### DIFF
--- a/advanced/i2c-sensor-reading/examples/part_2.rs
+++ b/advanced/i2c-sensor-reading/examples/part_2.rs
@@ -73,7 +73,7 @@ fn main() -> anyhow::Result<()>  {
             \n 
             ",
 
-            gyro_data.x, gyro_data.y, gyro_data.y, 
+            gyro_data.x, gyro_data.y, gyro_data.z, 
             measurement.temperature.as_degrees_celsius(), measurement.humidity.as_percent(),
         );
 


### PR DESCRIPTION
gyro data of axis y is printed twice, probably just a simple typo fix